### PR TITLE
docker-compose upで動くように

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
-FROM golang:onbuild
+FROM golang:1.12.7
+
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,5 @@ app:
   ports:
     - "8000:8000"
   volumes:
-    - ".:/go/src/app"
-  command: "make -C /go/src/app install server"
+    - ".:/go/src/github.com/co3k/go-webvuln"
+  command: "make -C /go/src/github.com/co3k/go-webvuln install server"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ app:
     - "8000:8000"
   volumes:
     - ".:/go/src/app"
-  command: "make install server"
+  command: "make -C /go/src/app install server"


### PR DESCRIPTION
fix #1 

## 修正点

1. docker imageを公式推奨のものに
  * refs. https://github.com/Microsoft/vscode-docker/issues/176
2. コンテナ内のmake叩いてる場所にMakefileなさそうだったのを修正
3. godep restoresでエラーでたのでvolumeするパスを変更

## 動作確認

```
~/src/github.com/saxsir/go-webvuln on  i1-cannot-build-docker-image ⌚ 17:54:29
$ docker-compose up --build
Building app
Step 1/2 : FROM golang:1.12.7
 ---> be63d15101cb
Step 2/2 : EXPOSE 8000
 ---> Using cache
 ---> 809a0c17f175
Successfully built 809a0c17f175
Successfully tagged go-webvuln_app:latest
Recreating go-webvuln_app_1 ... done
Attaching to go-webvuln_app_1
app_1  | make: Entering directory '/go/src/github.com/co3k/go-webvuln'
app_1  | which godep || go get github.com/tools/godep
app_1  | godep restore
app_1  | go run webvuln.go
app_1  | Starting up the server
```